### PR TITLE
timestamp the image

### DIFF
--- a/internal/image/image.go
+++ b/internal/image/image.go
@@ -23,6 +23,7 @@ import (
 
 	"debug/elf"
 	"debug/pe"
+	"time"
 
 	"github.com/google/go-containerregistry/pkg/crane"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
@@ -35,6 +36,7 @@ import (
 func baseImage() (*v1.Image, error) {
 	newImage := empty.Image
 	ociConfigFile, err := partial.ConfigFile(newImage)
+	ociConfigFile.Created = v1.Time{time.Now()}
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Fixes https://github.com/nubificus/bima/issues/8

This uses the system current time as the creation time for the resulting image.